### PR TITLE
Explicitly destroy chart on data change

### DIFF
--- a/src/tc-angular-chartjs.js
+++ b/src/tc-angular-chartjs.js
@@ -96,15 +96,12 @@
           function ( value ) {
 
             if ( value ) {
+              if ( chartObj ) {
+                chartObj.destroy();
+              }
               if ( chartType ) {
-                if ( chartObj ) {
-                  chartObj.destroy();
-                }
                 chartObj = chart[ cleanChartName( chartType ) ]( $scope.data, $scope.options );
               } else if ($scope.type) {
-                if ( chartObj ) {
-                  chartObj.destroy();
-                }
                 chartObj = chart[ cleanChartName( $scope.type ) ]( $scope.data, $scope.options );
               } else {
                 throw 'Error creating chart: Chart type required.';


### PR DESCRIPTION
When changing chart data, the old chart is left in the canvas with the new one rendered on top. This isn't a major issue until you hover over a chart. With multiple charts drawn, old segments still retain their event listeners and will draw tooltips on hover.

This PR addresses the issue by destroying the chart object if it exists before recreating it.

(Sorry for double PR, forgot to branch)
