### PR TITLE
Destroy chartjs object on directive destroy

### DIFF
--- a/src/tc-angular-chartjs.js
+++ b/src/tc-angular-chartjs.js
@@ -87,7 +87,7 @@
           if ( chartObj ) {
             chartObj.destroy();
           }
-        }
+        });
 
         $scope.$watch(
           'data',


### PR DESCRIPTION
Hi,

Please check if this works for you as well.

I had problems when using the directive in a partial that was closed - then resize events would keep flooding to handle the now undefined chart.

br
Lars
