### PR TITLE
Repair DI so that using ngStrictDi works

### DIFF
--- a/src/tc-angular-chartjs.js
+++ b/src/tc-angular-chartjs.js
@@ -7,14 +7,14 @@
   'use strict';
   angular
     .module( 'tc.chartjs', [] )
-    .directive( 'tcChartjs', TcChartjs )
-    .directive( 'tcChartjsLine', TcChartjsLine )
-    .directive( 'tcChartjsBar', TcChartjsBar )
-    .directive( 'tcChartjsRadar', TcChartjsRadar )
-    .directive( 'tcChartjsPolararea', TcChartjsPolararea )
-    .directive( 'tcChartjsPie', TcChartjsPie )
-    .directive( 'tcChartjsDoughnut', TcChartjsDoughnut )
-    .directive( 'tcChartjsLegend', TcChartjsLegend )
+    .directive( 'tcChartjs', [ "TcChartjsFactory", TcChartjs ] )
+    .directive( 'tcChartjsLine', [ "TcChartjsFactory", TcChartjsLine ] )
+    .directive( 'tcChartjsBar', [ "TcChartjsFactory", TcChartjsBar ] )
+    .directive( 'tcChartjsRadar', [ "TcChartjsFactory", TcChartjsRadar ] )
+    .directive( 'tcChartjsPolararea', [ "TcChartjsFactory", TcChartjsPolararea ] )
+    .directive( 'tcChartjsPie', [ "TcChartjsFactory", TcChartjsPie ] )
+    .directive( 'tcChartjsDoughnut', [ "TcChartjsFactory", TcChartjsDoughnut ] )
+    .directive( 'tcChartjsLegend', [ "TcChartjsFactory", TcChartjsLegend ] )
     .factory( 'TcChartjsFactory', TcChartjsFactory );
 
   function TcChartjs( TcChartjsFactory ) {


### PR DESCRIPTION
Hello, only a small change: somewhere along the lines (we haven't updated from source since 1.0.2) the DI in the directives got lost, breaking [ngStrictDI](https://docs.angularjs.org/api/ng/directive/ngApp).

Hopefully this won't have broken any tests - I'm not set up with any of the test stuff on this machine.