### PR TITLE
let the browser render the DOM before resizing the chart

### DIFF
--- a/src/tc-angular-chartjs.js
+++ b/src/tc-angular-chartjs.js
@@ -120,7 +120,13 @@
               if ( exposeChart ) {
                 $scope.chart = chartObj;
               }
-              chartObj.resize();
+
+              // let browser render before resizing chart
+              setTimeout(function () {
+                if (chartObj) {
+                  chartObj.resize(chartObj.render, true);
+                }
+              });
             }
 
           },


### PR DESCRIPTION
This commit uses setTimeout() in order to wait until the browser has rendered the DOM. This fixes an issue in my application where the chart isn't rendered on page load.