### PR TITLE
Fix compile error for Angular 1.5.0-rc.1

### DIFF
--- a/src/tc-angular-chartjs.js
+++ b/src/tc-angular-chartjs.js
@@ -55,8 +55,8 @@
           data: '=chartData',
           options: '=chartOptions',
           type: '@chartType',
-          legend: '=chartLegend',
-          chart: '=chart',
+          legend: '=?chartLegend',
+          chart: '=?chart',
           click: '&chartClick'
         },
         link: link


### PR DESCRIPTION
upgrading angular causes the following error to occur for attributes that are not required

https://docs.angularjs.org/error/$compile/nonassign?p0=undefined&p1=tcChartjsBar

console output:

```
Error: [$compile:nonassign] Expression 'undefined' used with directive 'tcChartjsBar' is non-assignable!
http://errors.angularjs.org/1.5.0-rc.1/$compile/nonassign?p0=undefined&p1=tcChartjsBar
    at angular.js:68
    at parentSet (angular.js:9487)
    at parentValueWatch (angular.js:9500)
    at Object.regularInterceptedExpression (angular.js:15098)
    at Scope.$digest (angular.js:16538)
    at Scope.$apply (angular.js:16810)
    at done (angular.js:11186)
    at completeRequest (angular.js:11384)
    at XMLHttpRequest.requestLoaded (angular.js:11325)
```